### PR TITLE
feat: open frame

### DIFF
--- a/app/api/frame/home/route.ts
+++ b/app/api/frame/home/route.ts
@@ -86,9 +86,6 @@ export async function POST(req: NextRequest) {
           <meta name="fc:frame:input:text" content="Enter EIP/ERC No" />
           <meta name="fc:frame:button:1" content="Search ⚡" />
 
-          <meta property="og:title" content="EIP.tools" />
-          <meta property="og:image" content="${imageUrl}" />
-
           <meta name="of:version" content="vNext" />
           <meta name="of:accepts:anonymous" content=true" />
           <meta name="of:image" content="${imageUrl}" />

--- a/app/api/frame/home/route.ts
+++ b/app/api/frame/home/route.ts
@@ -51,6 +51,9 @@ export async function POST(req: NextRequest) {
             validEIP.isERC ? "ERC" : "EIP"
           }-${eipNo}" />
           <meta name="of:button:2:action" content="link" />
+          <meta name="of:button:2:target" content="${
+            process.env["HOST"]
+          }/eip/${eipNo}" />
           </head>
           <body/>
         </html>`,

--- a/app/api/frame/home/route.ts
+++ b/app/api/frame/home/route.ts
@@ -37,6 +37,20 @@ export async function POST(req: NextRequest) {
           <meta name="fc:frame:button:2:target" content="${
             process.env["HOST"]
           }/eip/${eipNo}" />
+
+
+          <meta name="of:version" content="vNext" />
+          <meta name="of:accepts:anonymous" content=true" />
+          <meta name="of:image" content="${imageUrl}" />
+          <meta name="of:post_url" content="${postUrl}" />
+            
+          <meta name="of:input:text" content="Enter EIP/ERC No" />
+          <meta name="of:button:1" content="Search 🔎" />
+
+          <meta name="of:button:2" content="📙 ${
+            validEIP.isERC ? "ERC" : "EIP"
+          }-${eipNo}" />
+          <meta name="of:button:2:action" content="link" />
           </head>
           <body/>
         </html>`,
@@ -68,6 +82,16 @@ export async function POST(req: NextRequest) {
           
           <meta name="fc:frame:input:text" content="Enter EIP/ERC No" />
           <meta name="fc:frame:button:1" content="Search ⚡" />
+
+          <meta property="og:title" content="EIP.tools" />
+          <meta property="og:image" content="${imageUrl}" />
+
+          <meta name="of:version" content="vNext" />
+          <meta name="of:accepts:anonymous" content=true" />
+          <meta name="of:image" content="${imageUrl}" />
+          <meta name="of:post_url" content="${postUrl}" />
+          <meta name="of:input:text" content="Enter EIP/ERC No" />
+          <meta name="of:button:1" content="Search ⚡" />
         </head>
         <body/>
       </html>`,

--- a/app/eip/[eipOrNo]/layout.tsx
+++ b/app/eip/[eipOrNo]/layout.tsx
@@ -47,6 +47,15 @@ export async function generateMetadata({
       "fc:frame:button:2": `📙 ${validEIPData.isERC ? "ERC" : "EIP"}-${eipNo}`,
       "fc:frame:button:2:action": "link",
       "fc:frame:button:2:target": `${process.env["HOST"]}/eip/${eipNo}`,
+      "of:version": "vNext",
+      "of:accepts:anonymous": "true",
+      "of:image": imageUrl,
+      "of:post_url": postUrl,
+      "of:input:text": "Enter EIP/ERC No",
+      "of:button:1": "Search 🔎",
+      "of:button:2": `📙 ${validEIPData.isERC ? "ERC" : "EIP"}-${eipNo}`,
+      "of:button:2:action": "link",
+      "of:button:2:target": `${process.env["HOST"]}/eip/${eipNo}`,
     },
   };
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,12 @@ export async function generateMetadata(): Promise<Metadata> {
       "fc:frame:post_url": postUrl,
       "fc:frame:input:text": "Enter EIP/ERC No",
       "fc:frame:button:1": "Search 🔎",
+      "of:version": "vNext",
+      "of:image": imageUrl,
+      "of:post_url": postUrl,
+      "of:input:text": "Enter EIP/ERC No",
+      "of:button:1": "Search 🔎",
+      "of:authenticated": "false",
     },
   };
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
       "of:post_url": postUrl,
       "of:input:text": "Enter EIP/ERC No",
       "of:button:1": "Search 🔎",
-      "of:authenticated": "false",
+      "of:accepts:anonymous": "true",
     },
   };
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,11 +23,11 @@ export async function generateMetadata(): Promise<Metadata> {
       "fc:frame:input:text": "Enter EIP/ERC No",
       "fc:frame:button:1": "Search 🔎",
       "of:version": "vNext",
+      "of:accepts:anonymous": "true",
       "of:image": imageUrl,
       "of:post_url": postUrl,
       "of:input:text": "Enter EIP/ERC No",
       "of:button:1": "Search 🔎",
-      "of:accepts:anonymous": "true",
     },
   };
 }


### PR DESCRIPTION
ty for building this awesome tool!

Add tags for [Open Frame](https://github.com/open-frames/standard) compatibility.

`of:accepts:anonymous` is added to follow [this proposed pattern](https://github.com/open-frames/standard/pull/5) of designating a Frame as not requiring authentication, allowing it to be rendered by any app supporting Open Frames regardless of auth protocol (XMTP, Lens, etc.).

Can be tested [here](https://frames-js-debugger.vercel.app/).